### PR TITLE
Fix a NoMethodError on Fixnum metrics

### DIFF
--- a/lib/riemann/dash/helper/renderer.rb
+++ b/lib/riemann/dash/helper/renderer.rb
@@ -142,7 +142,7 @@ module Riemann
           end.merge o[:maxima]
         else
           states.inject(Hash.new(0)) do |m, s|
-            if s.metric && !(s.metric.nan?)
+            if s.metric && !(s.metric.respond_to?(:nan?) && s.metric.nan?)
               m[s.service] = [s.metric, m[s.service]].max
             end
             m


### PR DESCRIPTION
Metrics that come back as a Fixnum fail the nan? test at runtime in renderer.rb:state_chart.

Cheers
