### PR TITLE
support collectd threshold states in dashboard CSS

### DIFF
--- a/lib/riemann/dash/views/css.scss
+++ b/lib/riemann/dash/views/css.scss
@@ -164,7 +164,7 @@ html,table {
   @include vendor-prefix(transition, all 0.3s linear);
 }
 
-.state.ok, .bar.ok {
+.state.ok, .state.okay, .bar.ok, .bar.okay {
   background: $green;
   color: #000;
 }
@@ -172,7 +172,7 @@ html,table {
   background: $amber;
   color: #000;
 }
-.state.critical, .bar.critical {
+.state.critical, .state.failure, .bar.critical, .bar.failure {
   background: $orange;
   color: #000;
 }


### PR DESCRIPTION
After this patch, pointing a tuned collectd install including [thresholds](https://github.com/collectd/collectd/blob/master/src/collectd-threshold.pod) will highlight threshold warnings and failures directly in the riemann dashboard.

Note this is not a "clean" change, as it includes adjustments to allow clean integration with collectd:
- Riemann uses ok|warning|critical to colour states in the dashboard.
- CollectD sends okay|warning|failure notifications via @pyr's `write_riemann` plugin, along with the original event.

Alternatively this could be patched on collectd side, or rewritten in `riemann.config`.
