### PR TITLE
Allow expired events in the grid and style with phonecian purple

### DIFF
--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -385,11 +385,7 @@
   
   // Accept an event.
   Grid.prototype.update = function(e) {
-    if (e.state === "expired") {
-      this.remove(e);
-    } else {
-      this.add(e);
-    }
+    this.add(e);
   }
 
   Grid.prototype.reflow = function() {

--- a/lib/riemann/dash/views/css.scss
+++ b/lib/riemann/dash/views/css.scss
@@ -176,6 +176,10 @@ html,table {
   background: $orange;
   color: #000;
 }
+.state.expired {
+  background: $purple;
+  color: #000;
+}
 
 .view .query {
   display: block;


### PR DESCRIPTION
This does what I want, but likely needs a solution to allow the expired events to be removed gracefully at some point from the dashboard.

I'm not sure what that would look like, so here's enough of a patch to spark the discussion.

![purple](https://f.cloud.github.com/assets/284368/465766/791351ea-b642-11e2-993e-b35a3321ed16.png)
