### PR TITLE
Grid view features

### DIFF
--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -47,11 +47,21 @@
     this.query = json.query;
     this.title = json.title;
     this.max = json.max;
+    this.transpose = json.transpose;
     this.rows_str = json.rows;
     this.cols_str = json.cols;
     this.max_fn = max_fn(json.max);
-    this.row_fn = extract_fn(json.rows) || extract_fn('host');
-    this.col_fn = extract_fn(json.cols) || extract_fn('service');
+
+    if ( this.transpose == 'true' )
+    {
+      this.row_fn = extract_fn(json.rows) || extract_fn('service');
+      this.col_fn = extract_fn(json.cols) || extract_fn('host');
+    }
+    else
+    {
+      this.row_fn = extract_fn(json.rows) || extract_fn('host');
+      this.col_fn = extract_fn(json.cols) || extract_fn('service');
+    }
     this.clickFocusable = true;
 
     // Initial display
@@ -93,7 +103,8 @@
       query: this.query,
       max: this.max,
       rows: this.rows_str,
-      cols: this.cols_str
+      cols: this.cols_str,
+      transpose: this.transpose
     });
   }
   
@@ -109,7 +120,9 @@
     "<span class='desc'>'host' or 'service'</span><br />" +
     "<label for='max'>Max</label>" +
     "<input type='text' name='max' value=\"{{-max}}\" /><br />" +
-    "<span class='desc'>'all', 'host', 'service', or any number.</span>"
+    "<span class='desc'>'all', 'host', 'service', or any number.</span><br />" +
+    "<label for='transpose'>Transpose</label>" +
+    "<input type='text' name='transpose' value=\"{{-transpose}}\" placeholder='true or false' /><br />"
   )
 
   Grid.prototype.editForm = function() {

--- a/lib/riemann/dash/views/css.scss
+++ b/lib/riemann/dash/views/css.scss
@@ -257,7 +257,7 @@ html,table {
   left: 0;
   height: 0;
   width: 0;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .focusOverlay {


### PR DESCRIPTION
Hi there,

at work we're using riemann and riemann-dash to monitor our production environment.

Having lots of metrics to keep an eye on, we found useful the possibility to scroll each Grid view independently in a single tab. Furthermore, sometimes it could be more effective organizing the Grid for having metrics in rows instead of hosts.

In the code I added

```
overflow: auto; 
```

to `grid` class in the stylesheet and a `transpose` field, in `grid.js`.
