### PR TITLE
Reworked row/column label trimming in grid.js.

### DIFF
--- a/lib/riemann/dash/public/views/flot.js
+++ b/lib/riemann/dash/public/views/flot.js
@@ -56,7 +56,7 @@
             }
         );
       }
-    }
+    };
 
     // Set up our FlotView class and register it with the view system
     view.inherit(view.View, FlotView);
@@ -95,7 +95,7 @@
           max: t
         }
       });
-    }
+    };
 
     // Re-order the data list and series index to be in sorted order by label. 
     FlotView.prototype.resortSeries = function() {
@@ -160,11 +160,11 @@
       if (this.graph) {
         this.graph.setData(this.data);
       }
-    }
+    };
 
     // Clean up old data points.
     FlotView.prototype.trimData = function(t) {
-      var t = t - this.timeRange;
+      t = t - this.timeRange;
       var empties = false;
 
       _.each(this.data, function(s) {
@@ -187,7 +187,7 @@
         });
         this.resortSeries();
       }
-    }
+    };
 
     // Serialize current state to JSON
     FlotView.prototype.json = function() {
@@ -197,7 +197,7 @@
         query: this.query,
         timeRange: this.timeRange / 1000
       });
-    }
+    };
 
     // HTML template used to edit this view
     var editTemplate = _.template(
@@ -227,12 +227,12 @@
         this.graph.setupGrid();
         this.graph.draw();
       }
-    }
+    };
 
     // Called when our parent needs to resize us
     FlotView.prototype.reflow = function() {
       this.reflowGraph();
-    }
+    };
 
     // When the view is deleted, remove our subscription
     FlotView.prototype.delete = function() {
@@ -243,6 +243,6 @@
         subs.unsubscribe(this.sub);
       }
       view.View.prototype.delete.call(this);
-    }
+    };
 })();
 

--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -19,9 +19,9 @@
 
     // Property access
     return function(e) {
-      return e[str]
-    }
-  }
+      return e[str];
+    };
+  };
 
   // Takes a string and returns either:
   // - a function which extracts a maximum value from an event.
@@ -29,15 +29,15 @@
   var max_fn = function(str) {
     if ((!str) || str === "all") {
       // Always the same value: global maxima
-      return function(e) { return "all" };
+      return function(e) { return "all"; };
     }
     if (isNaN(parseFloat(str))) {
       // Not a number. Extract a field.
-      return function(e) { return e[str] };
+      return function(e) { return e[str]; };
     }
     // Return a constant number.
     return parseFloat(str);
-  }
+  };
 
   var Grid = function(json) {
     // We want a per-grid slurred rendering.
@@ -80,7 +80,7 @@
         me.update.call(me, e);
       });
     }
-  }
+  };
 
   view.inherit(view.View, Grid);
   view.Grid = Grid;
@@ -95,7 +95,7 @@
       rows: this.rows_str,
       cols: this.cols_str
     });
-  }
+  };
   
   var editTemplate = _.template(
     "<label for='title'>Title</label>" +
@@ -110,21 +110,21 @@
     "<label for='max'>Max</label>" +
     "<input type='text' name='max' value=\"{{-max}}\" /><br />" +
     "<span class='desc'>'all', 'host', 'service', or any number.</span>"
-  )
+  );
 
   Grid.prototype.editForm = function() {
     return editTemplate(this);
-  }
+  };
 
   // Returns all events, flat.
   Grid.prototype.allEvents = function() {
     var events = [];
-    for (row in this.events) {
-      for (column in this.events[row]) {
+    for (var row in this.events) {
+      for (var column in this.events[row]) {
         events.push(this.events[row][column]);
       }
     }
-  }
+  };
 
   // What is the maximum for this event?
   Grid.prototype.eventMax = function(event) {
@@ -136,7 +136,7 @@
       var max_key = this.max_fn(event);
       return this.maxima[this.max_fn(event)] || -1/0;
     } 
-  }
+  };
 
   // Generates a td cell for an event. Returns a map of the td, bar, and metric
   // elements.
@@ -145,7 +145,7 @@
     var bar = td.find('.bar');
     var metric = td.find('.metric');
     return {td: td, bar: bar, metric: metric};
-  }
+  };
 
   // Update a single jq element with information about an event.
   Grid.prototype.renderElement = function(e, event) {
@@ -170,7 +170,7 @@
     e.metric.text(format.float(event.metric));
 
     // Bar chart
-    if (event.metric == 0) {
+    if (event.metric === 0) {
       // Zero
       e.bar.css('width', 0);
     } else if (0 < event.metric) {
@@ -181,7 +181,7 @@
       // Nil or negative
       e.bar.css('width', 0);
     }
-  }
+  };
 
   // Render a single event if there's been no change to table structure.
   Grid.prototype.partialRender = function(event) {
@@ -194,7 +194,7 @@
 
       // Update cache
       if (!this.elCache[rowKey]) {
-        this.elCache[rowKey] = {}
+        this.elCache[rowKey] = {};
       }
       this.elCache[rowKey][colKey] = cache;
      
@@ -207,7 +207,7 @@
     }
 
     this.renderElement(cache, event);
-  }
+  };
 
   // A full re-rendering of the table.
   Grid.prototype.render = function() {
@@ -219,18 +219,18 @@
     var rowPrefix = strings.commonPrefix(this.rows);
     var colPrefixLen = colPrefix.length;
     var rowPrefixLen = rowPrefix.length;
-    var shortColNames = _.map(this.cols, function(s) {
-      if (s) {
-        return s.substring(colPrefixLen);
+
+    var shortener = function(fieldLen, s) {
+      var res = s;
+      if (s && s.length !== fieldLen) {
+        // Avoid trimming if it would trim the entire string.
+        res = s.substring(fieldLen);
       }
-      return s;
-    });
-    var shortRowNames = _.map(this.rows, function(s) {
-      if (s) {
-        return s.substring(rowPrefixLen);
-      }
-      return s;
-    });
+      return res;
+    }; 
+
+    var shortColNames = _.map(this.cols, _.partial(shortener, colPrefixLen));
+    var shortRowNames = _.map(this.rows, _.partial(shortener, rowPrefixLen));
 
     // Header
     table.append("<thead><tr><th></th></tr></thead>");
@@ -264,7 +264,7 @@
         row.append(cache.td);
       }, this);
     }, this);
-  }
+  };
 
   // Update cached maxima with a new event. Returns true if maxima changed.
   Grid.prototype.updateMax = function(event) {
@@ -292,8 +292,8 @@
     // Traverse all events looking for a match.
     var e;
     var currentMax = -1/0;
-    for (name in this.events) {
-      for (subName in this.events[name]) {
+    for (var name in this.events) {
+      for (var subName in this.events[name]) {
         e = this.events[name][subName];
         if (e.metric && this.max_fn(e) === max_key) {
           currentMax = Math.max(currentMax, e.metric);
@@ -305,7 +305,7 @@
     this.maxima[max_key] = currentMax;
 
     return true;
-  }
+  };
 
   // Stores an event in the internal state tables. Returns true if we
   // haven't seen this host/service before.
@@ -336,7 +336,7 @@
     this.events[row_key][col_key] = e;
 
     return newEvent;
-  }
+  };
 
   // Add an event.
   Grid.prototype.add = function(e) {
@@ -348,7 +348,7 @@
     } else {
       this.partialRender(e);
     }
-  }
+  };
 
   // Remove an event.
   Grid.prototype.remove = function(e) {
@@ -361,7 +361,7 @@
       delete this.elCache[row_key][col_key];
       if (_.isEmpty(this.events[row_key])) {
         delete this.events[row_key];
-      };
+      }
     }
     if (_.isEmpty(this.elCache[row_key])) {
       delete this.events[row_key];
@@ -381,25 +381,25 @@
 
     this.updateMax();
     this.render();
-  }
+  };
   
   // Accept an event.
   Grid.prototype.update = function(e) {
     this.add(e);
-  }
+  };
 
   Grid.prototype.reflow = function() {
     // this.el.find('table').height(
     //   this.height() -
     //   this.el.find('h2').height()     
     // );
-  }
+  };
 
   Grid.prototype.delete = function() {
-    if (this.sub != undefined) {
+    if (this.sub !== undefined) {
       subs.unsubscribe(this.sub);
     }
     this.update = function() {};
     view.View.prototype.delete.call(this);
-  }
+  };
 })();


### PR DESCRIPTION
Regards https://github.com/aphyr/riemann-dash/issues/33.

How about this? Suppose 4 hosts: nil, host, host1, host2, host3.

After trimming, the labels should be: nil, host, 1, 2, 3.

Also, JSHint yelled at me so I put in some semicolons.
