### PR TITLE
grid view: display events timestamp in human-readable format

### DIFF
--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -163,7 +163,7 @@
 
     // Description
     e.td.attr('title', event.host + ' ' + event.service + "\n" +
-        event.state + ' at ' + event.time + "\n\n" +
+        event.state + ' at ' + new Date(event.time).toString() + "\n\n" +
         event.description);
 
     // Metric


### PR DESCRIPTION
... as opposed to milliseconds since the epoch.
