### PR TITLE
Config#store is not updated based on configuration

### DIFF
--- a/lib/riemann/dash/config.rb
+++ b/lib/riemann/dash/config.rb
@@ -37,12 +37,15 @@ class Riemann::Dash::Config
     store[k] = v
   end
 
+  alias_method :set, :"[]="
 
   # Executes the configuration file.
   def load_config(path)
     self.config_path = path
     begin
-      Riemann::Dash::App.instance_eval File.read(config_path)
+      opts = File.read(config_path)
+      self.instance_eval opts
+      Riemann::Dash::App.instance_eval opts
       true
     rescue Errno::ENOENT
       false


### PR DESCRIPTION
When testing Riemann-dash and configuring a custom ws_config directory -
specifically inside a /home/riemann-dash folder, it turned out that the
property was not overridable through riemann-dash.rb with a sinatra config.

The reason for this is that #Config lib/riemann/dash/config.rb is initialised
as a singleton :(App < Sinatra::Base)#settings instead?, see
http://www.sinatrarb.com/contrib/config_file.html
https://ididitmyway.herokuapp.com/past/2010/11/9/sinatra_settings_and_configuration/

So this is a 'fix' that doesn't refactor the settings, but keeps
Riemann::Dash::Config.

Example output before fix (adding some debug code):

```
app: self.load called for file /etc/riemann/riemann-dash.rb
setting up default config values, merging config {} with some defaults
loading config from /etc/riemann/riemann-dash.rb: set :bind, '0.0.0.0'
set :port, 4567
set :environment, :production
== Sinatra/1.4.3 has taken the stage on 4567 for production with backup from
Thin
>> Thin web server (v1.5.1 codename Straight Razor)
>> Maximum connections set to 1024
>> Listening on 0.0.0.0:4567, CTRL+C to stop
```

After:

```
app: self.load called for file /etc/riemann/riemann-dash.rb
setting up default config values, merging config {} with some defaults
loading config from /etc/riemann/riemann-dash.rb: set :bind, '0.0.0.0'
set :port, 4567
set :environment, :production
set :ws_config, '/home/riemann-dash/config/config.json'
setting bind: 0.0.0.0
setting port: 4567
setting environment: production
setting ws_config: /home/riemann-dash/config/config.json
== Sinatra/1.4.3 has taken the stage on 4567 for production with backup from
Thin
>> Thin web server (v1.5.1 codename Straight Razor)
>> Maximum connections set to 1024
>> Listening on 0.0.0.0:4567, CTRL+C to stop
```
