### PR TITLE
s/:host/:bind/

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ Dash class, and hence, all Sinatra configuration.
 
 ``` ruby
 set :port, 6000      # HTTP server on port 6000
-set :host, "1.2.3.4" # Bind to a different port
+set :bind, "1.2.3.4" # Bind to a different interface
 config[:ws_config] = 'custom/config.json' # Specify custom workspace config
 ```
 


### PR DESCRIPTION
Sinatra uses `:bind` to specify the interface to bind to: http://www.sinatrarb.com/configuration.html#bind---server-hostname-or-ip-address
