### PR TITLE
Optional server-sent-event connection type.

### DIFF
--- a/lib/riemann/dash/config.rb
+++ b/lib/riemann/dash/config.rb
@@ -142,6 +142,9 @@ class Riemann::Dash::Config
     # Server
     new_config['server'] = update['server'] or old['server']
 
+    # Server Type
+    new_config['server_type'] = update['server_type'] or old['server_type']
+
     #p update['workspaces']
     new_config['workspaces'] = update['workspaces'] or old['workspaces']
 

--- a/lib/riemann/dash/public/dash.js
+++ b/lib/riemann/dash/public/dash.js
@@ -134,8 +134,11 @@ dash = (function() {
     persistence.load(function(config) {
       // Server
       var server = config.server || '127.0.0.1:5556';
+      var server_type = config.server_type || "ws";
       subs.server(server);
+      subs.server_type(server_type);
       toolbar.server(server);
+      toolbar.server_type(server_type);
 
       // Workspaces
       if (config.workspaces) {
@@ -173,6 +176,7 @@ dash = (function() {
     persistence.save(
       {
         server: toolbar.server(),
+        server_type: toolbar.server_type(),
         workspaces: workspaces
       },
       function() { toastr.info("Configuration saved.") },
@@ -231,6 +235,13 @@ dash = (function() {
     console.log("Server changed to", server);
     // Notify subscription system
     subs.server(server);
+    // Reload view.
+    switchWorkspace(currentWorkspace());
+  });
+
+  toolbar.onServerTypeChange(function (server_type) {
+    console.log("Server type changed to", server_type);
+    subs.server_type(server_type);
     // Reload view.
     switchWorkspace(currentWorkspace());
   });

--- a/lib/riemann/dash/public/subs.js
+++ b/lib/riemann/dash/public/subs.js
@@ -3,6 +3,9 @@ var subs = (function() {
   // What server shall we connect to by default?
   var server;
 
+  // What type of connection should we emit ?
+  var server_type;
+
   // Subscription ID counter.
   var id_counter = -1;
 
@@ -54,24 +57,36 @@ var subs = (function() {
     },
 
     isOpen: function() {
-      return this.ws && (this.ws.readyState != WebSocket.CLOSED)
+      if (server_type == "ws") {
+        return this.ws && (this.ws.readyState != EventSource.CLOSED)
+      } else {
+        return this.ws && (this.ws.readyState != WebSocket.CLOSED)
+      }
     },
     isClosed: function() { return !this.isOpen() },
 
     url: function() {
       var queryString = "query=" + encodeURIComponent(this.query);
       var loc = window.location, ws_uri;
-      if (loc.protocol === "https:") {
-          ws_uri = "wss://";
+
+      if (server_type == "sse") {
+        return loc.protocol + "//" + server + "/index?" + queryString;
       } else {
-          ws_uri = "ws://";
+        ws_uri = (loc.protocol == "https:") ? "wss://" : "ws://";
+        return ws_uri + server + "/index?subscribe=true&" + queryString;
       }
-      return ws_uri + server + "/index?subscribe=true&" + queryString;
     },
 
     open: function() {
       if (this.isOpen()) return this;
-      var ws = this.ws = new WebSocket(this.url());
+	console.log("will open url: " + this.url());
+
+      var ws;
+      if (server_type == "sse") {
+        ws = this.ws = new EventSource(this.url());
+      } else {
+        ws = this.ws = new WebSocket(this.url());
+      }
 
       ws.onopen = _.bind(function() {
         console.log("Socket opened", this.query);
@@ -182,6 +197,14 @@ var subs = (function() {
         return server;
       } else {
         server = s;
+        return s;
+      }
+    },
+    server_type: function(s) {
+      if (s === undefined) {
+        return server_type;
+      } else {
+        server_type = s;
         return s;
       }
     }

--- a/lib/riemann/dash/public/toolbar.js
+++ b/lib/riemann/dash/public/toolbar.js
@@ -7,7 +7,12 @@ var toolbar = (function() {
   var pager = $('<div class="pager">');
   var load = $('<div class="load"><div class="bar load1" /><div class="bar load5" /><span title="1- and 5-second subscription manager load averages">Load</span></div>');
   var server = $('<input class="server" type="text" name="text">');
+  var server_type = $('<div class="server"><label><input type="radio" id="ws" name="server_type" value="ws" checked>websockets</label><input type="radio" id="sse" name="server_type" value="sse">sse</label></div>');
+  var server_type_selector = $("input[name=server_type]");
+  var server_type_sse_selector = $("input#ws");
+  var server_type_ws_selector = $("input#sse");
   form.append(pager);
+  form.append(server_type);
   form.append(server);
   form.append(load);
   form.submit(function(e) { 
@@ -28,16 +33,36 @@ var toolbar = (function() {
 
   // Callbacks
   var onServerChangeCallbacks = [];
+  var onServerTypeChangeCallbacks = [];
 
   // React to server being set.
   var onServerChange = function(callback) {
     onServerChangeCallbacks.push(callback);
   }
 
+  var onServerTypeChange = function(callback) {
+    onServerTypeChangeCallbacks.push(callback);
+  }
+
   // When server is set, call callbacks.
   server.change(function() {
     onServerChangeCallbacks.forEach(function(f) {
       f(server.val());
+    });
+    server.blur();
+  });
+
+  // When server_type is set, call callbacks.
+  $('input#ws').change(function(e) {
+    onServerTypeChangeCallbacks.forEach(function(f) {
+      f($("input[name=server_type]:checked").val());
+    });
+    server.blur();
+  });
+
+  $('input#sse').change(function(e) {
+    onServerTypeChangeCallbacks.forEach(function(f) {
+      f($("input[name=server_type]:checked").val());
     });
     server.blur();
   });
@@ -205,7 +230,22 @@ var toolbar = (function() {
         return s;
       }
     },
+    server_type: function(s) {
+      if (s === undefined) {
+        return $("input[name=server_type]:checked").val();
+      } else {
+        console.log("handling server_type: " + s);
+	if (s == "sse") {
+          $("input[name=server_type]#sse").attr("checked",true);
+        } else if (s == "ws") {
+          $("input[name=server_type]#ws").attr("checked",true);
+        }
+        return s;
+      }
+    },
+      
     onServerChange: onServerChange,
+    onServerTypeChange: onServerTypeChange,
     onWorkspaceChange: onWorkspaceChange,
     onWorkspaceReorder: onWorkspaceReorder,
     onWorkspaceSwitch: onWorkspaceSwitch,


### PR DESCRIPTION
Add a checkbox allowing switching between server-sent-event and websocket mode. This keeps websocket as the default mode. People wanting to run this will most likely need the following configuration in riemann:

``` clojure
  (sse-server :headers {"Access-Control-Allow-Origin" "*"})
```
