### PR TITLE
avoid error when trying to delete non-existing array element

### DIFF
--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -354,7 +354,9 @@
   Grid.prototype.remove = function(e) {
     var row_key = this.row_fn(e);
     var col_key = this.col_fn(e);
-    delete this.events[row_key][col_key];
+    if (this.events[row_key][col_key]) {
+      delete this.events[row_key][col_key];
+    }
 
     // Wipe element cache
     if (this.elCache[row_key]) {


### PR DESCRIPTION
@aphyr, so this was the error we talked about on IRC. It was (re)introduced by the revert you did (67335d6). Before this `Grid.prototype.remove` was dead code, from what I understood.
