### PR TITLE
Show state when availible for events with no metric

### DIFF
--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -170,6 +170,8 @@
     // Metric
     if (event.metric != undefined) {
       e.metric.text(format.float(event.metric));
+    } else if (event.state != undefined) {
+      e.metric.text(event.state);
     }
 
     // Bar chart


### PR DESCRIPTION
```
aphyr │ But yeah, I think if metrics are missing, it should fall back to showing states
aphyr │ Would be a really easy PR if you want to get your hands dirty :)
```
