### PR TITLE
Log view does not limit the number of events

### DIFF
--- a/lib/riemann/dash/public/views/log.js
+++ b/lib/riemann/dash/public/views/log.js
@@ -76,6 +76,9 @@
     // Accept events from a subscription and update the log.
     LogView.prototype.update = function(event) {
       this.log.append(this.lineTemplate(event));
+      while (this.log[0].children.length > this.lines) {
+          this.log[0].deleteRow(0);
+      }
       if (this.tracking) { this.scrollToBottom(); };
     };
 


### PR DESCRIPTION
The `LogView` added in `0.2.8` keeps appending new events without ever discarding previous events. The `lines` option for the view implies it can be used to limit the number of log entries, but does not appear to do anything.
