### PR TITLE
only focus if CTRL/Meta+click is pressed

### DIFF
--- a/lib/riemann/dash/public/view.js
+++ b/lib/riemann/dash/public/view.js
@@ -125,9 +125,11 @@ var view = (function() {
     var self = this;
     this.clickFocusable = true;
     this.el.click(function() {
-      if (self.clickFocusable) {
-        self.focus();
-      }
+        if (event.ctrlKey || event.metaKey) {
+            if (self.clickFocusable) {
+                self.focus();
+            }
+        }
     });
   };
   types.View = View;

--- a/lib/riemann/dash/public/views/help.js
+++ b/lib/riemann/dash/public/views/help.js
@@ -6,7 +6,7 @@
       this.el.append('<div class="box">' +
         "<p>Welcome to Riemann-Dash.</p>" +
         "<p>Need a refresher on the query language? See the <a href=\"https://github.com/aphyr/riemann/blob/master/test/riemann/query_test.clj\">query tests</a> for examples, or read the <a href=\"https://github.com/aphyr/riemann/blob/master/src/riemann/Query.g\">spec</a>.</p>" +
-        "<p>Click to select a view. Escape unfocuses. Use the arrow keys to move a view. Use Control+arrow to <i>split</i> a view in the given direction.</p>" +
+        "<p>Press <b>Control/Meta+click</b>  to select a view. Escape unfocuses. Use the arrow keys to move a view. Use Control+arrow to <i>split</i> a view in the given direction.</p>" +
         "<p>To edit a view, hit e. Use enter, or click 'apply', to apply your changes. Escape cancels.</p>" +
         "<p>To save your changes to the server, press s. You can refresh the page, or press r to reload.</p>" +
         "<p>Make views bigger and smaller with the +/- keys. Pageup selects the parent of the current view. To delete a view, use the delete key.</p>" +


### PR DESCRIPTION
This change the way you select (focus) a view, you need to press ctrl or meta then click in order to select a view. 
The reason behind this is that, before if  you try to select text on the dashboard that will trigger focus on a view and was a bit uncomfortable to work with. 
