### PR TITLE
Add pageup to popup help

### DIFF
--- a/lib/riemann/dash/public/dash.js
+++ b/lib/riemann/dash/public/dash.js
@@ -202,6 +202,7 @@ dash = (function() {
       '<li><b>&#8594;</b>: right arrow move the view to the right</li>' +
       '<li><b>&#8593;</b>: up arrow move the view up</li>' +
       '<li><b>&#8595;</b>: down arrow move the view down</li>' +
+      '<li><b>pageup</b>: select the parent of the current view</li>' +
       '<li><b>d</b>: delete a view</li>' +
       '<li><b>delete</b>: delete a view</li>' +
       '<li><b>alt-1, alt-2, etc</b>: switch to a different workplace</li>' +


### PR DESCRIPTION
I completely missed the sentence on the documentation page about how to select the parent of the current view.
