### PR TITLE
Add default values for LogView event objects

### DIFF
--- a/lib/riemann/dash/public/views/log.js
+++ b/lib/riemann/dash/public/views/log.js
@@ -75,7 +75,14 @@
 
     // Accept events from a subscription and update the log.
     LogView.prototype.update = function(event) {
-      this.log.append(this.lineTemplate(event));
+      var defaults = {
+        host: "",
+        service: "",
+        state: "",
+        metric: "",
+        description: ""
+      }
+      this.log.append(this.lineTemplate(_.defaults(event, defaults)));
       while (this.log[0].children.length > this.lines) {
           this.log[0].deleteRow(0);
       }


### PR DESCRIPTION
If any of the required keys are not present in the event object,
underscore's template rendering function will throw an exception.

Closes #70
