### PR TITLE
Fish up 0.2.9

### DIFF
--- a/lib/riemann/dash/version.rb
+++ b/lib/riemann/dash/version.rb
@@ -1,4 +1,4 @@
 module Riemann; end
 module Riemann::Dash
-  VERSION = '0.2.8'
+  VERSION = '0.2.9'
 end


### PR DESCRIPTION
When you look at 6e76c97618, the github interface shows it belong to 2 tags (0.2.8 and 0.2.9) and 1 branch (master). When you look at a9a51e84bf it belongs to one tag (0.2.9) and no branch! When you look at https://github.com/aphyr/riemann-dash/blob/master/lib/riemann/dash/version.rb (the tip of the master branch) you see it's still 0.2.8.

Probably a9a51e84bf was commited in 'detached HEAD' state or something. This simply recovers this commit and its associated tag.
