### PR TITLE
Allow grid to be scrollable

### DIFF
--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -22,7 +22,7 @@
     this.el.addClass('grid');
     this.el.append(
       '<h2></h2>' +
-      '<div class="container"><table></table></div>'
+      '<div class="container scroll"><table></table></div>'
     );
     this.box = this.el.find('.box');
     this.el.find('h2').text(this.title);


### PR DESCRIPTION
As we keep adding rows to a grid, they start becoming unreachable. This allows vertical scrolling on grids.
