### PR TITLE
Added description field when hover on grid

### DIFF
--- a/lib/riemann/dash/public/views/grid.js
+++ b/lib/riemann/dash/public/views/grid.js
@@ -16,6 +16,7 @@
     this.col_sort = json.col_sort || "lexical";
     this.row_fn = util.extract_fn(json.rows) || util.extract_fn('host');
     this.col_fn = util.extract_fn(json.cols) || util.extract_fn('service');
+    this.description = json.description;
     this.clickFocusable = true;
 
     // Initial display
@@ -57,7 +58,8 @@
       rows: this.rows_str,
       cols: this.cols_str,
       row_sort: this.row_sort,
-      col_sort: this.col_sort
+      col_sort: this.col_sort,
+      description: this.description
     });
   };
 
@@ -83,7 +85,9 @@
     "</select><br />" +
     "<label for='max'>Max</label>" +
     "<input type='text' name='max' value=\"{{-max}}\" /><br />" +
-    "<span class='desc'>'all', 'host', 'service', or any number.</span>"
+    "<span class='desc'>'all', 'host', 'service', or any number.</span><br />" +
+    "<label for='description'>Description</label>" +
+    "<textarea name='description'>{{-description}}</textarea><br />"
   );
 
   Grid.prototype.editForm = function() {
@@ -219,8 +223,23 @@
     td.attr('class', "state box " + event.state);
 
     // Description
-    td.attr('title', event.host + ' ' + event.service + "\n" + event.state +
-        "\nreceived at " + new Date(event.time).toString() +
+    var list = [];
+    if(this.json().description != undefined){
+        list = this.json().description.split(',');
+    }
+    var description = "";
+    list.forEach(function(input){
+        if(input === "all"){
+            for(k in event){
+                description += k + ': ' + event[k] + '\n';
+            }
+        }
+        if(event[input] != undefined){
+            description += input + ": " + event[input] + '\n';
+        }
+    });
+    td.attr('title', event.host + ' ' + event.service + "\n" + event.state + '\n' + description +
+        "received at " + new Date(event.time).toString() +
         "\nexpiring at " + new Date(event.time + event.ttl * 1000).toString() +
         (event.description ? ("\n\n" + event.description) : ""));
 


### PR DESCRIPTION
With this patch, you can add a list of fields separated by dashs for example:

```
host,service,ttl
```

By using all, every fields will be added.
