### PR TITLE
[fix] missing label opening tag for "sse"

### DIFF
--- a/lib/riemann/dash/public/toolbar.js
+++ b/lib/riemann/dash/public/toolbar.js
@@ -15,7 +15,7 @@ var toolbar = (function() {
   var pager = $('<div class="pager">');
   var load = $('<div class="load"><div class="bar load1" /><div class="bar load5" /><span title="1- and 5-second subscription manager load averages">Load</span></div>');
   var server = $('<input class="server" type="text" name="text">');
-  var server_type = $('<div class="server"><label><input type="radio" id="ws" name="server_type" value="ws" checked>websockets</label><input type="radio" id="sse" name="server_type" value="sse">sse</label></div>');
+  var server_type = $('<div class="server"><label><input type="radio" id="ws" name="server_type" value="ws" checked>websockets</label><label><input type="radio" id="sse" name="server_type" value="sse">sse</label></div>');
   var server_type_selector = $("input[name=server_type]");
   var server_type_sse_selector = $("input#ws");
   var server_type_ws_selector = $("input#sse");


### PR DESCRIPTION
Hello,

I re-ported riemann-dash to engineio+godot2+nodejs and in the process discovered a missing opening tag for `<label>`.

Thanks for your work!
