### PR TITLE
replace keys used for showconfig to avoid conflicts when copying text…

### DIFF
--- a/lib/riemann/dash/public/dash.js
+++ b/lib/riemann/dash/public/dash.js
@@ -237,7 +237,7 @@ dash = (function() {
   keys.bind(80, subs.toggle); // p
   keys.bind(82, reload);      // r
   keys.bind(83, save);        // s
-  keys.bind(67, showconfig);  // c
+  keys.bind(87, showconfig);  // w
   keys.bind(191, help);       // ?
   keys.bind(49, function(e) { e.altKey && switchWorkspace(workspaces[0]) });
   keys.bind(50, function(e) { e.altKey && switchWorkspace(workspaces[1]) });


### PR DESCRIPTION
… from screen

On my mac whenever I press cmd+c to copy text from the dashboard the showconfig also pop's up