### PR TITLE
Fix documentation on how to display configuration

### DIFF
--- a/lib/riemann/dash/public/dash.js
+++ b/lib/riemann/dash/public/dash.js
@@ -208,7 +208,7 @@ dash = (function() {
       '<li><b>e</b>: edit the view</li>' +
       '<li><b>?</b>: display this help box</li>' +
       '<li><b>s</b>: save the dashboard</li>' +
-      '<li><b>c</b>: display the current config</li>' +
+      '<li><b>w</b>: display the current config</li>' +
       '<li><b>r</b>: reload the dashboard from last saved config</li>' +
       '<li><b>+</b>: increase the size of the view</li>' +
       '<li><b>-</b>: decrease the size of the view</li>' +

--- a/lib/riemann/dash/public/views/help.js
+++ b/lib/riemann/dash/public/views/help.js
@@ -9,7 +9,7 @@
         "<p>Double-click a workspace to rename it.</p>" +
         "<p>Press <b>Control/Meta+click</b> to select a view (<b>Option+Command+click</b> on a Mac). Escape unfocuses. Use the arrow keys to move a view. Use Control+arrow to <i>split</i> a view in the given direction.</p>" +
         "<p>To edit a view, hit e. Use enter, or click 'apply', to apply your changes. Escape cancels.</p>" +
-        "<p>To save your changes to the server, press s. To display the configuration, press c.</p>" +
+        "<p>To save your changes to the server, press s. To display the configuration, press w.</p>" +
         "<p>You can refresh the page, or press r to reload.</p>" +
         "<p>Make views bigger and smaller with the +/- keys. Pageup selects the parent of the current view. To delete a view, use the delete key or press d.</p>" +
         "<p>Switch between workspaces with alt-1, alt-2, etc.</p>" +


### PR DESCRIPTION
Commit db439a8bc033e4fc10f5005efec875be5d622ea2 changes the key for displaying configuration from "c" to "w". However, the default dash and help modal box don't display this change, potentially confusing new users (read: me) trying to press "c". This patch updates the documentation.