### PR TITLE
Fix the ´No such file or directory´ error when opening the index page.

### DIFF
--- a/lib/riemann/dash/controller/index.rb
+++ b/lib/riemann/dash/controller/index.rb
@@ -1,6 +1,6 @@
 class Riemann::Dash::App
   get '/' do
-    erb :index, :layout => false
+    erubis :index, :layout => false
   end
 
   get '/config', :provides => 'json' do


### PR DESCRIPTION
The controller was trying to render the index.erb instead of index.erubis.

<img width="1349" alt="screen shot 2018-04-14 at 18 44 58" src="https://user-images.githubusercontent.com/4949616/38770503-42981ab8-4014-11e8-9124-ccae77e30b52.png">
