### PR TITLE
Improve UI

### DIFF
--- a/lib/riemann/dash/public/eventPane.js
+++ b/lib/riemann/dash/public/eventPane.js
@@ -14,7 +14,7 @@ var eventPane = (function() {
       '<span class="ttl">{{-ttl}}</span>' +
       '<span class="tags">{{-tags}}</span>' +
       '</div>' +
-      '<div class="description">{{-description}}</div>');
+      '<pre class="description">{{-description}}</pre>');
 
   var rowTemplate =
         _.template("<tr><td>{{-field}}</td><td>{{-value}}</td></tr>");

--- a/lib/riemann/dash/public/eventPane.js
+++ b/lib/riemann/dash/public/eventPane.js
@@ -45,14 +45,18 @@ var eventPane = (function() {
             tags: "nil",
             description: "nil"})));
 
-    var table = el.append('<table></table>');
+    var table = '<table>'
 
     // Remaining fields
     _.each(event, function(value, field) {
       if (! _.contains(fixedFields, field)) {
-        table.append(rowTemplate({field: field, value: value}));
+        table += rowTemplate({field: field, value: value});
       }
     });
+
+    table += '</table>';
+
+    el.append(table);
   };
 
   // Hide on escape.

--- a/lib/riemann/dash/public/eventPane.js
+++ b/lib/riemann/dash/public/eventPane.js
@@ -17,7 +17,7 @@ var eventPane = (function() {
       '<pre class="description">{{-description}}</pre>');
 
   var rowTemplate =
-        _.template("<tr><td>{{-field}}</td><td>{{-value}}</td></tr>");
+        _.template('<tr><td class="field-name">{{-field}}</td><td>{{-value}}</td></tr>');
 
   // Hide the pane
   var hide = function() {

--- a/lib/riemann/dash/public/eventPane.js
+++ b/lib/riemann/dash/public/eventPane.js
@@ -5,14 +5,16 @@ var eventPane = (function() {
   var fixedFields = ['host', 'service', 'time', 'state', 'metric', 'ttl', 'description', 'tags'];
   var fixedTemplate =
     _.template(
-      '<div class="host">{{-host}}</div>' +
-      '<div class="service">{{-service}}</div>' +
-      '<div class="state {{-state}}">{{-state}}</div>' +
-      '<div class="metric">{{-metric}}</div>' +
+      '<div>' +
+      '<span class="host">{{-host}}</span>' +
+      '<span class="service">{{-service}}</span>' +
+      '<span class="state {{-state}}">{{-state}}</span>' +
+      '<span class="metric">{{-metric}}</span>' +
       '<time class="absolute">{{-time}}</time>' +
-      '<div class="ttl">{{-ttl}}</div>' +
-      '<div class="tags">{{-tags}}</div>' +
-      '<div class="description">{{-description}}</description>');
+      '<span class="ttl">{{-ttl}}</span>' +
+      '<span class="tags">{{-tags}}</span>' +
+      '</div>' +
+      '<div class="description">{{-description}}</div>');
 
   var rowTemplate =
         _.template("<tr><td>{{-field}}</td><td>{{-value}}</td></tr>");

--- a/lib/riemann/dash/public/format.js
+++ b/lib/riemann/dash/public/format.js
@@ -6,7 +6,11 @@ var format = (function() {
 		}
     precision = precision || 2;
     var base = Math.pow(10, precision);
-    var val =  Math.round(number * base) / base;
+    var val;
+    if (Math.round(number) == number)
+      val = number;
+    else
+      val = number.toFixed(precision);
 
     if(!commas) {
       return val;

--- a/lib/riemann/dash/views/css.scss
+++ b/lib/riemann/dash/views/css.scss
@@ -147,7 +147,6 @@ html,table {
   }
 
   * {
-    float: left;
     padding: 3px;
   }
 
@@ -172,6 +171,7 @@ html,table {
   }
 
   .description {
+    float: left;
     clear: both;
     white-space: pre-wrap;
   }

--- a/lib/riemann/dash/views/css.scss
+++ b/lib/riemann/dash/views/css.scss
@@ -167,7 +167,12 @@ html,table {
 
   .tags:before {
     color: $grey;
-    content: "tags: ";
+    content: "tags ";
+  }
+
+  .field-name {
+    color: $grey;
+    text-align: right;
   }
 
   .description {

--- a/lib/riemann/dash/views/css.scss
+++ b/lib/riemann/dash/views/css.scss
@@ -174,6 +174,7 @@ html,table {
     float: left;
     clear: both;
     white-space: pre-wrap;
+    margin: 3px;
   }
 }
 


### PR DESCRIPTION
- Fix extra attributes table markup
- Respect inline and block elements logic
- Display description using a monospaced font
- Improve attributes display consistency
- Make rounding more consistent

Before | After
----|-----
Output of `ps(1)` is hard to read because of the non-monospaced font, custom attribute (*customer*, *user*) are not display like the usual ones (*ttl*, *tags*) | More readable `ps(1)` output, all attributes are displayed the same way
![Before](https://user-images.githubusercontent.com/148721/198748412-559a248f-1a41-41b2-92c0-b12643ebf0f5.png) | ![After](https://user-images.githubusercontent.com/148721/198748439-6a7c9895-ec37-43aa-a242-2c63dfe2bd28.png)
Some floating points number have a single digit after the decimal place (2.4) | Floating-points numbers always have 2 digits after the decimal place
![Before](https://user-images.githubusercontent.com/148721/205136527-ec809352-cd10-4ffd-9e6e-ba1ece7f3140.png) | ![After](https://user-images.githubusercontent.com/148721/205136680-8f3293a6-5f6f-4077-9abf-c88ab867baae.png)



