### PR TITLE
Add support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - 2.7
           - 3.0
           - 3.1
+          - 3.2
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,44 +11,67 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    async (1.30.3)
-      console (~> 1.10)
-      nio4r (~> 2.3)
-      timers (~> 4.1)
-    async-http (0.56.6)
-      async (>= 1.25)
-      async-io (>= 1.28)
-      async-pool (>= 0.2)
-      protocol-http (~> 0.22.0)
-      protocol-http1 (~> 0.14.0)
-      protocol-http2 (~> 0.14.0)
-      traces (~> 0.4.0)
-    async-http-faraday (0.11.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    async (2.12.1)
+      console (~> 1.25, >= 1.25.2)
+      fiber-annotation
+      io-event (~> 1.6, >= 1.6.5)
+    async-http (0.69.0)
+      async (>= 2.10.2)
+      async-pool (~> 0.7)
+      io-endpoint (~> 0.11)
+      io-stream (~> 0.4)
+      protocol-http (~> 0.26)
+      protocol-http1 (~> 0.19)
+      protocol-http2 (~> 0.18)
+      traces (>= 0.10)
+    async-http-faraday (0.14.0)
       async-http (~> 0.42)
       faraday
-    async-io (1.33.0)
-      async
-    async-pool (0.3.10)
+    async-pool (0.7.0)
       async (>= 1.25)
-    concurrent-ruby (1.1.10)
-    console (1.15.3)
-      fiber-local
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    console (1.25.2)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
+    drb (2.2.1)
     erubi (1.9.0)
-    faraday (2.3.0)
-      faraday-net_http (~> 2.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-http-cache (2.4.0)
+    faraday (2.9.2)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-http-cache (2.5.1)
       faraday (>= 0.8)
-    faraday-net_http (2.0.3)
-    ffi (1.15.5)
-    fiber-local (1.0.0)
+    faraday-net_http (3.1.0)
+      net-http
+    ffi (1.17.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (0.1.2)
     github_changelog_generator (1.16.4)
       activesupport
       async (>= 1.25.0)
@@ -58,31 +81,37 @@ GEM
       octokit (~> 4.6)
       rainbow (>= 2.2.1)
       rake (>= 10.0)
-    i18n (1.10.0)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.16.1)
+    io-endpoint (0.11.0)
+    io-event (1.6.5)
+    io-stream (0.4.0)
+    json (2.7.2)
+    minitest (5.24.1)
     multi_json (1.3.6)
-    mustermann (1.1.1)
+    mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.5.8)
-    octokit (4.25.0)
+    mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
+    octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    protocol-hpack (1.4.2)
-    protocol-http (0.22.6)
-    protocol-http1 (0.14.4)
+    protocol-hpack (1.4.3)
+    protocol-http (0.26.6)
+    protocol-http1 (0.19.1)
       protocol-http (~> 0.22)
-    protocol-http2 (0.14.2)
+    protocol-http2 (0.18.0)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.18)
-    public_suffix (4.0.7)
-    rack (2.2.3.1)
-    rack-protection (2.2.0)
+    public_suffix (6.0.0)
+    rack (2.2.9)
+    rack-protection (2.2.4)
       rack
     rainbow (3.1.1)
-    rake (13.0.6)
-    rb-fsevent (0.11.1)
-    rb-inotify (0.10.1)
+    rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
     ruby2_keywords (0.0.5)
     sass (3.7.4)
@@ -93,20 +122,31 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
+    sinatra (2.2.4)
+      mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.2.0)
+      rack-protection (= 2.2.4)
       tilt (~> 2.0)
-    tilt (2.0.10)
-    timers (4.3.3)
-    traces (0.4.1)
-    tzinfo (2.0.4)
+    tilt (2.4.0)
+    traces (0.11.1)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    webrick (1.7.0)
+    uri (0.13.0)
+    webrick (1.8.1)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  amd64-freebsd-14
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   github_changelog_generator
@@ -115,4 +155,4 @@ DEPENDENCIES
   riemann-dash!
 
 BUNDLED WITH
-   1.17.2
+   2.5.13

--- a/lib/riemann/dash/browser_config/file.rb
+++ b/lib/riemann/dash/browser_config/file.rb
@@ -7,7 +7,7 @@ class Riemann::Dash::BrowserConfig::File
   end
 
   def read
-    if ::File.exists? @path
+    if ::File.exist? @path
       ::File.open(@path, 'r') do |f|
         f.flock ::File::LOCK_SH
         f.read


### PR DESCRIPTION
Ruby 2.2 deprecated `File#exists?` in favor of `File#exist?`, and Ruby
3.2 removed the deprecated method.

We need to use the "new" method to run on Ruby 3.2.
